### PR TITLE
Test Bad Parallel Words

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,4 @@
 use Mix.Config
 
+# Define a Mock for wherever the authoritative dictionary is derived
 config :letter_lines_elixir, dictionary_file_provider: LetterLinesElixir.DictionaryFileProvider.Mock

--- a/lib/letter_lines_elixir/board_state.ex
+++ b/lib/letter_lines_elixir/board_state.ex
@@ -125,7 +125,7 @@ defmodule LetterLinesElixir.BoardState do
     if Range.disjoint?(y1..(y1 + size1), y2..(y2 + size2 - 1)) do
       :ok
     else
-      raise "These two horizontal words are parallel and touching: #{word1} and #{word2}"
+      raise "These two horizontal words are parallel and touching: #{word1.word} and #{word2.word}"
     end
   end
 
@@ -136,7 +136,7 @@ defmodule LetterLinesElixir.BoardState do
     if Range.disjoint?(x1..(x1 + size1 - 1), x2..(x2 + size2 - 1)) do
       :ok
     else
-      raise "These two vertical words are parallel and touching: #{word1} and #{word2}"
+      raise "These two vertical words are parallel and touching: #{word1.word} and #{word2.word}"
     end
   end
 end

--- a/lib/letter_lines_elixir/game_state.ex
+++ b/lib/letter_lines_elixir/game_state.ex
@@ -11,16 +11,12 @@ defmodule LetterLinesElixir.GameState do
           score: integer(),
           picked_words: list(String.t())
         }
-  def new(letters) do
+  def new(board_state) do
     %GameState{
-      letter_list: letters,
-      board_state: generate_board_state_from_letters(letters),
+      # letter_list: letters, #### This should call a BoardState function, find the largest word, and split into list
+      board_state: board_state,
       score: 0,
       picked_words: []
     }
-  end
-
-  defp generate_board_state_from_letters(_letters) do
-    %BoardState{}
   end
 end

--- a/test/letter_lines_elixir/board_state_test.exs
+++ b/test/letter_lines_elixir/board_state_test.exs
@@ -91,7 +91,25 @@ defmodule LetterLinesElixir.BoardStateTest do
       end
     end
 
-    test "will raise if a parallel word is touching another word" do
+    test "will raise if two horizontal, parallel words are touching" do
+      assert_raise RuntimeError, "These two horizontal words are parallel and touching: urn and burn", fn ->
+        BoardState.new([
+          BoardWord.new(0, 0, :h, "burn"),
+          BoardWord.new(1, 1, :h, "urn")
+        ])
+      end
+    end
+
+    test "will raise if two vertical, parallel words are touching" do
+      assert_raise RuntimeError, "These two vertical words are parallel and touching: urn and burn", fn ->
+        BoardState.new([
+          BoardWord.new(0, 0, :v, "burn"),
+          BoardWord.new(1, 1, :v, "urn")
+        ])
+      end
+    end
+
+    test "at least one word that uses all available letters is present" do
     end
   end
 
@@ -106,6 +124,12 @@ defmodule LetterLinesElixir.BoardStateTest do
     end
 
     test "returns the letter when found at given location" do
+      board_state = BoardState.new(@board_words)
+      assert "b" = BoardState.get_letter_at(board_state, 5, 0)
+      assert "c" = BoardState.get_letter_at(board_state, 0, 1)
+      assert "h" = BoardState.get_letter_at(board_state, 0, 2)
+      assert "n" = BoardState.get_letter_at(board_state, 3, 4)
+      assert "h" = BoardState.get_letter_at(board_state, 5, 4)
     end
 
     test "raises when multiple letters are found at the same location" do


### PR DESCRIPTION
Correct the error raised if parallel words are found to be touching,
and add tests to cover those checks