### PR TITLE
Create Pool of Usable Letters

### DIFF
--- a/lib/letter_lines_elixir/board_state.ex
+++ b/lib/letter_lines_elixir/board_state.ex
@@ -41,6 +41,11 @@ defmodule LetterLinesElixir.BoardState do
     }
   end
 
+  def get_usable_letter_list(%BoardState{} = state) do
+    %BoardWord{word: word} = longest_word(state)
+    String.graphemes(word)
+  end
+
   def get_letter_at(%BoardState{words: words}, x, y) do
     do_get_letter_at(words, x, y)
   end
@@ -52,6 +57,20 @@ defmodule LetterLinesElixir.BoardState do
       |> Enum.map(&get_display_letter_at(board_state, &1, y))
       |> Enum.join("")
       |> IO.puts()
+    end
+  end
+
+  def longest_word(%BoardState{words: words}) do
+    longest_word(words)
+  end
+
+  def longest_word([word]), do: word
+
+  def longest_word([%BoardWord{word: word1} = bw1, %BoardWord{word: word2} = bw2 | tail]) do
+    if String.length(word1) > String.length(word2) do
+      longest_word([bw1 | tail])
+    else
+      longest_word([bw2 | tail])
     end
   end
 

--- a/lib/letter_lines_elixir/game_state.ex
+++ b/lib/letter_lines_elixir/game_state.ex
@@ -13,7 +13,7 @@ defmodule LetterLinesElixir.GameState do
         }
   def new(board_state) do
     %GameState{
-      # letter_list: letters, #### This should call a BoardState function, find the largest word, and split into list
+      letter_list: BoardState.get_usable_letter_list(board_state),
       board_state: board_state,
       score: 0,
       picked_words: []

--- a/test/letter_lines_elixir/board_state_test.exs
+++ b/test/letter_lines_elixir/board_state_test.exs
@@ -144,4 +144,10 @@ defmodule LetterLinesElixir.BoardStateTest do
       end
     end
   end
+
+  test "get_usable_letter_list/1 returns all letters from the longest BoardState word" do
+    board_state = BoardState.new(@board_words)
+
+    assert ["b", "r", "u", "n", "c", "h"] = BoardState.get_usable_letter_list(board_state)
+  end
 end

--- a/test/letter_lines_elixir/game_state_test.exs
+++ b/test/letter_lines_elixir/game_state_test.exs
@@ -2,15 +2,23 @@ defmodule LetterLinesElixir.GameStateTest do
   use ExUnit.Case
 
   alias LetterLinesElixir.BoardState
+  alias LetterLinesElixir.BoardWord
   alias LetterLinesElixir.GameState
 
-  @tag :skip
-  test "new/1 returns an initialized game state" do
-    letters = ["a", "b", "c"]
-    new_game = GameState.new(letters)
+  @board_words [
+    BoardWord.new(5, 0, :v, "bunch"),
+    BoardWord.new(0, 1, :v, "chub"),
+    BoardWord.new(3, 1, :v, "burn"),
+    BoardWord.new(0, 1, :h, "curb"),
+    BoardWord.new(0, 4, :h, "brunch")
+  ]
+
+  test "new/1 returns a properly initialized game state" do
+    board_state = BoardState.new(@board_words)
+    new_game = GameState.new(board_state)
 
     assert %GameState{} = new_game
-    assert new_game.letter_list == letters
+    assert new_game.letter_list == ["b", "r", "u", "n", "c", "h"]
     assert %BoardState{} = new_game.board_state
     assert new_game.score == 0
     assert new_game.picked_words == []


### PR DESCRIPTION
Create a list of letters representing what a player can use. Each
puzzle will have at least one word that uses all available letters, and
any number of shorter words using subsets of that letter list.

Determine the letters by recursing over all `BoardWord`s in a
`BoardState` to determine the longest word, then split that word into
a list of binary letters. This builds an authoritative list and
resists the possible temptation of de-duping repetitive letters

Add call to this new functionality to `GameState` creation so the
`letters` key will be populated with correct values.

Add tests for both the `BoardState` and `GameState`